### PR TITLE
Fix: Adjust console text alignment and verify button centering

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -826,7 +826,7 @@ a:hover {
   }
 
   .hero-terminal .terminal-body {
-    text-align: right;
+    text-align: left;
   }
 }
 


### PR DESCRIPTION
- I modified `src/styles/main.css` to change the `text-align` property for `.hero-terminal .terminal-body` from `right` to `left` within the `@media (max-width: 768px)` media query. This ensures the console text is left-aligned on smaller screens as you requested.
- I verified that the `.scroll-down` button is already correctly centered using `position: absolute; left: 50%; transform: translateX(-50%);`. No changes were required for this element.